### PR TITLE
Mejora en el tiempo que se tarda en encontrar links a páginas de publicación

### DIFF
--- a/OutputDataSetCSV.py
+++ b/OutputDataSetCSV.py
@@ -32,3 +32,6 @@ class OuputDataSetCSV(object):
     def save(self):
         df = pd.DataFrame(data=self.dataset, columns=self.columns)
         df.to_csv(self.outputFileName, index=False, columns=self.columns, sep=';', quoting=csv.QUOTE_ALL, doublequote=True, quotechar='"', encoding="utf-8")    
+        excel_filename = self.outputFileName.replace(".csv", "") + ".xlsx"
+        print(excel_filename)
+        df.to_excel(excel_filename, index=False, columns=self.columns)

--- a/OutputDataSetCSV.py
+++ b/OutputDataSetCSV.py
@@ -16,8 +16,9 @@
 #    along with buscarTitulosFacebook; if not, write to the Free Software
 #    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-import pandas as pd
 import csv
+
+import pandas as pd
 
 
 class OuputDataSetCSV(object):
@@ -31,7 +32,5 @@ class OuputDataSetCSV(object):
 
     def save(self):
         df = pd.DataFrame(data=self.dataset, columns=self.columns)
-        df.to_csv(self.outputFileName, index=False, columns=self.columns, sep=';', quoting=csv.QUOTE_ALL, doublequote=True, quotechar='"', encoding="utf-8")    
-        excel_filename = self.outputFileName.replace(".csv", "") + ".xlsx"
-        print(excel_filename)
-        df.to_excel(excel_filename, index=False, columns=self.columns)
+        df.to_csv(self.outputFileName, index=False, columns=self.columns, sep=';', quoting=csv.QUOTE_ALL, doublequote=True, quotechar='"', encoding="utf-8")
+        df.to_excel(self.outputFileName.replace(".csv", "") + ".xlsx", index=False, columns=self.columns)

--- a/PostFacebook.py
+++ b/PostFacebook.py
@@ -27,7 +27,7 @@ from FacebookStringToNumber import FacebookStringToNumber
 from TextOutputFile import TextOutputFile
 from selenium.webdriver.common.keys import Keys
 from urllib.request import urlretrieve
-
+from selenium.common.exceptions import ElementNotInteractableException
 from PIL import Image
 
 
@@ -482,12 +482,15 @@ class PostFacebook():
         TEXT_DISPLAYED = 'Más'
         potential_blocks = self.fb_login.find_elements_by_xpath(F"//div[@class='{CLASS_NAME}']")
         for pb in potential_blocks:
-            inner_divs = pb.find_elements_by_xpath("//div[@aria-hidden='false']")
-            for in_d in inner_divs:
-                if TEXT_DISPLAYED in in_d.text:
+            if TEXT_DISPLAYED in pb.text:
+                try:
                     pb.click()
                     sleep(0.25)
                     return True
+                except ElementNotInteractableException:
+                    # The element is not clickable, if the whole for cycle finishes
+                    # that means the button 'Más' was not present
+                    continue
         return False
     
     def get_divs_for_additional_reactions(self):

--- a/buscarPosteosFacebook.py
+++ b/buscarPosteosFacebook.py
@@ -26,7 +26,7 @@ def getFBLogin(fb_user, fb_password, gecko_binary, gecko_driver_exe, headless=Fa
     loginbutton = driver.find_element_by_css_selector("button[name='login']")
     loginbutton.send_keys(Keys.ENTER)
     print("Facebook login...")
-    sleep(20)
+    sleep(15)
     return driver
 
 
@@ -58,7 +58,7 @@ def getFBSearchPage(driver, page, year):
     search_textbox = driver.find_element_by_css_selector("input[type='search'][aria-label]")
     search_textbox.send_keys(page)
     search_textbox.send_keys(Keys.ENTER)
-    sleep(20)
+    sleep(15)
     #body = driver.find_element_by_xpath('//body')
     #body.send_keys(Keys.TAB)
     #body.send_keys(Keys.TAB)
@@ -107,9 +107,9 @@ def getFBSearchPage(driver, page, year):
     return driver
 
 
-def getFBPostsLinks(driver, scroll_count):
+def getFBPostsLinks(driver, amount_of_publications):
     scroll_nro = 0
-    while HasScroll(driver) and scroll_nro < scroll_count:
+    while HasScroll(driver) and scroll_nro < 2:
         body = driver.find_element_by_xpath('//body')
         body.send_keys(Keys.CONTROL + Keys.END)
         now = datetime.now()
@@ -121,22 +121,43 @@ def getFBPostsLinks(driver, scroll_count):
     body = driver.find_element_by_xpath('//body')
     posts = body.find_elements_by_class_name('sjgh65i0')
     posts_links_html = []
-    for post in posts:
+    len_posts = len(posts)
+    for i, post in enumerate(posts):
+        print(f"POST {i+1} de {len_posts}", "*"*30)
         specific_span_tags = post.find_elements_by_xpath("//span[contains(@id, 'jsc_c')]")
-        for sst in specific_span_tags:
-            if "h" and "·" in sst.text:
+        len_spec_span_tags = len(specific_span_tags)
+        for j, sst in enumerate(specific_span_tags):
+            # print(f"SPAN {j+1} de {len_spec_span_tags}", "-"*30)
+
+            if len(posts_links_html) >= amount_of_publications:
+                break
+
+            if "·" in sst.text:
                 a_tags = sst.find_elements_by_tag_name("a")
-                for a_tag in a_tags:
-                    if "h" in a_tag.get_attribute("aria-label") and a_tag.get_attribute("role")=="link" and len(a_tags)==1:
+                len_a_tags = len(a_tags)
+                for k, a_tag in enumerate(a_tags):
+
+                    if len(posts_links_html) >= amount_of_publications:
+                        break
+
+                    # print(f"SPAN {k+1} de {len_a_tags}", "."*30)
+                    if a_tag.get_attribute("role")=="link":
                         # sometimes the obtained href value obtained might not be the specific link to the FB pub
                         # in those case, it'll change to the correct link once a click is executed over it
                         if "search" in a_tag.get_attribute("href"):
-                            # TODO: the syntax to find this object can be simplified and efienciency-improved
-                            a_tag.click()
+
+                            print("\n", a_tag.get_attribute("href"))
                             sleep(1)
+                            #print("ABOUT TO BE CLICKED")
+                            a_tag.click()
+                            print("CLICKED")
+                            print(a_tag.get_attribute("href"))
+
                         href = a_tag.get_attribute("href")
+                        print(a_tag.get_attribute("aria-label"))
                         inner_html = post.get_attribute("innerHTML")
-                        posts_links_html.append((href, inner_html))
+                        if href not  in [el[0] for el in posts_links_html]:
+                            posts_links_html.append((href, inner_html))
     return posts_links_html
 
 
@@ -172,7 +193,7 @@ def exportNetvizzCsv(config, posts_links):
             post.SaveHtml(config.base_path)
             posts = post.ParsePostHTML()
             posts_fb.append(posts)
-            sleep(17)
+            sleep(10)
         except Exception as ex:
             print("ERROR" + str(ex) + traceback.format_exc()) 
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ toml==0.10.1
 urllib3==1.25.10
 webdriver-manager==3.5.2
 wrapt==1.12.1
+termcolor==1.1.0


### PR DESCRIPTION
Draft:
- ~~Hay publicaciones que fallan al ser parseadas (no se puede parsear un dato como int), y quizás se resuelve sencillamente~~
- ~~Hay publicaciones que fallan durante las funciones de parseo pero por razones de Selenium~~
- ~~Falta cambiar el nombre del parámetro de scrolls por el de cantidad de publicaciones en la configuración~~

Cambios:
- No se usa más el parámetro "cantidad de scrolls hacia abajo"; ahora se usa "cantidad de publicaciones a ser scrapeadas"
- El tiempo se redujo creando la condición de "cantidad de publicaciones a ser scrapeadas", no usando mejor sintaxis de XPATH
- Arreglado bug: el script no falla para páginas de publicación sin el botón "Más"